### PR TITLE
Fix: vue animation name bug

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
 /*    /index.html   200 
+/*    /index.html   404

--- a/src/components/Fire.vue
+++ b/src/components/Fire.vue
@@ -20,7 +20,7 @@ export default {
       type: Number,
       default: 0,
     },
-  }
+  },
 };
 </script>
 
@@ -28,7 +28,6 @@ export default {
 .fire {
   height: 100px;
   width: 100px;
-  border-bottom-width: var(--x);
 }
 
 .flame {

--- a/src/components/FirstStage.vue
+++ b/src/components/FirstStage.vue
@@ -45,8 +45,10 @@ g.launched .stage-1 {
 }
 
 g.launched .stage-1 .fire {
-  animation-name: liftoff, s1Landing;
-  animation-duration: 1.0s, 1.7s;
+  /* The second animation worked in dev server but was being stripped out of the build. */
+  /* This seems like a Vue bug. To reproduce, remove the !important flag below. */
+  animation-name: liftoff, firstLanding !important;
+  animation-duration: 1s, 1.7s;
   animation-timing-function: linear, linear;
   animation-fill-mode: forwards, forwards;
   animation-delay: 0s, 2.5s;
@@ -70,7 +72,7 @@ g.launched .stage-1 .fire {
   }
 }
 
-@keyframes s1Landing {
+@keyframes firstLanding {
   0% {
     visibility: hidden;
   }

--- a/src/components/FirstStage.vue
+++ b/src/components/FirstStage.vue
@@ -45,7 +45,7 @@ g.launched .stage-1 {
 }
 
 g.launched .stage-1 .fire {
-  animation-name: liftoff, s1-landing;
+  animation-name: liftoff, s1Landing;
   animation-duration: 1.0s, 1.7s;
   animation-timing-function: linear, linear;
   animation-fill-mode: forwards, forwards;
@@ -70,7 +70,7 @@ g.launched .stage-1 .fire {
   }
 }
 
-@keyframes s1-landing {
+@keyframes s1Landing {
   0% {
     visibility: hidden;
   }

--- a/src/index.css
+++ b/src/index.css
@@ -11,13 +11,19 @@ a {
 }
 
 ul {
-  list-style-type: '🛰';
+  list-style: none;
   max-height: calc(100vh - 195px);
   overflow-y: auto;
 }
 
 ul a {
   margin-left: 5px;
+}
+
+li:before {
+  content: '\1F6F0';
+  margin-left: -30px;
+  margin-right: 8px;
 }
 
 li {


### PR DESCRIPTION
- Added `!important` flag to stop Vue from dropping second fire animation.
- Netlify redirect 404s to main page.
- Fixed 🛰 list style for Safari. 